### PR TITLE
added Makefile to use latexmk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # You want latexmk to *always* run, because make does not have all the info.
 # Also, include non-file targets in .PHONY so they are run regardless of any
 # file of the given name existing.
-.PHONY: sample-book.pdf all clean
+.PHONY: sample-book.pdf sample-handout.pdf all clean clean_all clean_bbl
 
 # The first rule in a Makefile is the one executed by default ("make"). It
 # should always be the "all" rule, so that "make" and "make all" are identical.
@@ -35,5 +35,11 @@ sample-book.pdf: sample-book.tex
 sample-handout.pdf: sample-handout.tex
 	latexmk -pdf -pdflatex="pdflatex -interaction=nonstopmode" -use-make sample-handout.tex
 
-clean:
+clean_all: clean_bbl
 	latexmk -CA
+
+clean: clean_bbl
+	latexmk -c
+
+clean_bbl:
+	-rm *.bbl

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+# You want latexmk to *always* run, because make does not have all the info.
+# Also, include non-file targets in .PHONY so they are run regardless of any
+# file of the given name existing.
+.PHONY: sample-book.pdf all clean
+
+# The first rule in a Makefile is the one executed by default ("make"). It
+# should always be the "all" rule, so that "make" and "make all" are identical.
+all: sample-book.pdf sample-handout.pdf
+
+# CUSTOM BUILD RULES
+
+# In case you didn't know, '$@' is a variable holding the name of the target,
+# and '$<' is a variable holding the (first) dependency of a rule.
+# "raw2tex" and "dat2tex" are just placeholders for whatever custom steps
+# you might have.
+
+%.tex: %.raw
+	./raw2tex $< > $@
+
+%.tex: %.dat
+	./dat2tex $< > $@
+
+# MAIN LATEXMK RULE
+
+# -pdf tells latexmk to generate PDF directly (instead of DVI).
+# -pdflatex="" tells latexmk to call a specific backend with specific options.
+# -use-make tells latexmk to call make for generating missing files.
+
+# -interaction=nonstopmode keeps the pdflatex backend from stopping at a
+# missing file reference and interactively asking you for an alternative.
+
+sample-book.pdf: sample-book.tex
+	latexmk -pdf -pdflatex="pdflatex -interaction=nonstopmode" -use-make sample-book.tex
+
+sample-handout.pdf: sample-handout.tex
+	latexmk -pdf -pdflatex="pdflatex -interaction=nonstopmode" -use-make sample-handout.tex
+
+clean:
+	latexmk -CA


### PR DESCRIPTION
Added `Makefile` for command line use to build `sample-handout.pdf` and `sample-book.pdf`.  

`$ make`
`$ make all`

builds both PDF files.  You can also build either one directly using the PDF file names:

`$ make sample-handout.pdf`
`$ make sample-book.pdf`

There is also a 

`$ make clean` 

which strips back to the repository contents (including PDFs).   If you want to delete the PDFs, just use:

`$ make clean_all`

